### PR TITLE
Add nix flake to make installation easier

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715668745,
+        "narHash": "sha256-xp62OkRkbUDNUc6VSqH02jB0FbOS+MsfMb7wL1RJOfA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ddcaffecdf098822d944d4147dd8da30b4e6843",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Cmake with webOs toolchain";
+
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64bit AMD/Intel x86
+        "aarch64-linux" # 64bit ARM
+        "x86_64-darwin" # 64bit AMD/Intel macOS
+        "aarch64-darwin" # 64bit ARM macOS
+      ];
+
+      forAllSystems = fn:
+        nixpkgs.lib.genAttrs allSystems
+        (system: fn { pkgs = import nixpkgs { inherit system; }; inherit system;});
+
+      webOsToolchain = {system, fetchurl, runCommand}: let 
+          urlToolchain = {
+              "x86_64-linux"  = "https://github.com/openlgtv/buildroot-nc4/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz";
+              "aarch64-linux" = "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_linux-aarch64.tar.bz2";
+              "x86_64-darwin" = "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_darwin-x86_64.tar.bz2";
+              "aarch64-darwin"= "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_darwin-arm64.tar.bz2";
+          }."${system}";
+
+          hashToolchain = {
+              "x86_64-linux"  = "sha256-MoFmJumfs0kipJ0MY598ijA1b/+yIjctSCMCfxOC9kA=";
+              "aarch64-linux" = "sha256-RaLRL/VXRX2SzeT92qd6bxCQ/KA63EO7dDl+Xgw3lQE=";
+              "x86_64-darwin" = "sha256-dedFGsOWBIcq5/B4lMvo7bYrIJFmSheByxk+fr5WqnU=";
+              "aarch64-darwin"= "sha256-lUMzaUqx/h93N+gaC+HjGIzf/8GhGcgchvX86/GFfEU=";
+          }."${system}";
+
+          webosToolchainPkg = fetchurl {
+            url = urlToolchain;
+            hash = hashToolchain;
+          };
+      in 
+        runCommand "webos-toolchain" {} ''
+          mkdir -p $out
+          tar -xf ${webosToolchainPkg} -C $out
+          mv $out/arm-webos-linux-gnueabi_sdk-buildroot/* $out
+          rm -rf $out/arm-webos-linux-gnueabi_sdk-buildroot
+        '';
+    in {
+
+      defaultPackage = forAllSystems ({ pkgs, system }: pkgs.callPackage webOsToolchain { inherit system; });
+
+      devShells = forAllSystems ({ pkgs, system }: let 
+          webOs = (pkgs.callPackage webOsToolchain { inherit system; });
+      in
+      {
+        default = pkgs.mkShell {
+          nativeBuildInputs = [ webOs pkgs.makeWrapper pkgs.cmake ];         
+          shellHook = ''
+            alias cmake="${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOs}/share/buildroot/toolchainfile.cmake"
+          '';
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Cmake with webOs toolchain";
+  description = "Cmake with webOS toolchain";
 
   inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11"; };
 
@@ -16,7 +16,7 @@
         nixpkgs.lib.genAttrs allSystems
         (system: fn { pkgs = import nixpkgs { inherit system; }; inherit system;});
 
-      webOsToolchain = {system, fetchurl, runCommand}: let 
+      webOSToolchain = {system, fetchurl, runCommand}: let 
           urlToolchain = {
               "x86_64-linux"  = "https://github.com/openlgtv/buildroot-nc4/releases/download/webos-d7ed7ee/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz";
               "aarch64-linux" = "https://github.com/webosbrew/native-toolchain/releases/download/webos-d7ed7ee.6/arm-webos-linux-gnueabi_sdk-buildroot_linux-aarch64.tar.bz2";
@@ -44,16 +44,20 @@
         '';
     in {
 
-      defaultPackage = forAllSystems ({ pkgs, system }: pkgs.callPackage webOsToolchain { inherit system; });
+      defaultPackage = forAllSystems ({ pkgs, system }: pkgs.callPackage webOSToolchain { inherit system; });
 
       devShells = forAllSystems ({ pkgs, system }: let 
-          webOs = (pkgs.callPackage webOsToolchain { inherit system; });
+          webOS = (pkgs.callPackage webOSToolchain { inherit system; });
       in
       {
         default = pkgs.mkShell {
-          nativeBuildInputs = [ webOs pkgs.cmake ];         
+          nativeBuildInputs = [ webOS pkgs.cmake ];         
           shellHook = ''
-            alias cmake="${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOs}/share/buildroot/toolchainfile.cmake"
+            alias cmake='${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOS}/share/buildroot/toolchainfile.cmake -DCMAKE_CXX_FLAGS="-I ${webOS}/include/glib-2.0 -I ${webOS}/lib/glib-2.0/include"'
+            function webos_cmake_kit {
+              mkdir -p .vscode
+              echo '${builtins.toJSON [{ name = "webos-toolchain"; toolchainFile = "${webOS}/share/buildroot/toolchainfile.cmake";}]}' > .vscode/cmake-kits.json
+            }
           '';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,10 @@
 
       webOsToolchain = {system, fetchurl, runCommand}: let 
           urlToolchain = {
-              "x86_64-linux"  = "https://github.com/openlgtv/buildroot-nc4/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz";
-              "aarch64-linux" = "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_linux-aarch64.tar.bz2";
-              "x86_64-darwin" = "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_darwin-x86_64.tar.bz2";
-              "aarch64-darwin"= "https://github.com/webosbrew/native-toolchain/releases/latest/download/arm-webos-linux-gnueabi_sdk-buildroot_darwin-arm64.tar.bz2";
+              "x86_64-linux"  = "https://github.com/openlgtv/buildroot-nc4/releases/download/webos-d7ed7ee/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz";
+              "aarch64-linux" = "https://github.com/webosbrew/native-toolchain/releases/download/webos-d7ed7ee.6/arm-webos-linux-gnueabi_sdk-buildroot_linux-aarch64.tar.bz2";
+              "x86_64-darwin" = "https://github.com/webosbrew/native-toolchain/releases/download/webos-d7ed7ee.6/arm-webos-linux-gnueabi_sdk-buildroot_darwin-x86_64.tar.bz2";
+              "aarch64-darwin"= "https://github.com/webosbrew/native-toolchain/releases/download/webos-d7ed7ee.6/arm-webos-linux-gnueabi_sdk-buildroot_darwin-arm64.tar.bz2";
           }."${system}";
 
           hashToolchain = {
@@ -51,7 +51,7 @@
       in
       {
         default = pkgs.mkShell {
-          nativeBuildInputs = [ webOs pkgs.makeWrapper pkgs.cmake ];         
+          nativeBuildInputs = [ webOs pkgs.cmake ];         
           shellHook = ''
             alias cmake="${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOs}/share/buildroot/toolchainfile.cmake"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
         default = pkgs.mkShell {
           nativeBuildInputs = [ webOS pkgs.cmake ];         
           shellHook = ''
-            alias cmake='${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOS}/share/buildroot/toolchainfile.cmake -DCMAKE_CXX_FLAGS="-I ${webOS}/include/glib-2.0 -I ${webOS}/lib/glib-2.0/include"'
+            alias cmake='${pkgs.cmake}/bin/cmake -DCMAKE_TOOLCHAIN_FILE=${webOS}/share/buildroot/toolchainfile.cmake'
             function webos_cmake_kit {
               mkdir -p .vscode
               echo '${builtins.toJSON [{ name = "webos-toolchain"; toolchainFile = "${webOS}/share/buildroot/toolchainfile.cmake";}]}' > .vscode/cmake-kits.json


### PR DESCRIPTION
This allows to install the toolchain in all supported architectures using Nix.

With the command: 

`nix develop github:rucadi/native-toolchain`

You will spawn a shell with the toolchain installed, all dependencies and the cmake command aliased to include the toolchain file.

I have only tested this on x86_64 linux, a compilation of SDL2 using this toolchain was successful.